### PR TITLE
Add milter packages to Docker image

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -65,6 +65,25 @@ jobs:
     - name: Verify SRS config contains domain
       run: docker exec postfix-test grep 'mail.example.com' /etc/default/postsrsd
 
+    - name: Verify milter packages are installed
+      run: |
+        docker exec postfix-test dpkg -l postgrey | grep -q '^ii'
+        docker exec postfix-test dpkg -l spamassassin | grep -q '^ii'
+        docker exec postfix-test dpkg -l spamass-milter | grep -q '^ii'
+        docker exec postfix-test dpkg -l opendmarc | grep -q '^ii'
+        docker exec postfix-test dpkg -l opendkim | grep -q '^ii'
+        docker exec postfix-test dpkg -l miltertest | grep -q '^ii'
+        docker exec postfix-test dpkg -l rsyslog | grep -q '^ii'
+        echo "All milter packages verified"
+
+    - name: Verify milter setup (vhome directory and SpamAssassin config)
+      run: |
+        docker exec postfix-test test -d /vhome/users
+        docker exec postfix-test stat -c '%U:%G' /vhome/users | grep -q 'debian-spamd:debian-spamd'
+        docker exec postfix-test grep -q 'score MISSING_DATE 0' /etc/spamassassin/local.cf
+        docker exec postfix-test grep -q 'score INVALID_DATE 0' /etc/spamassassin/local.cf
+        echo "Milter setup verified"
+
     - name: Show logs on failure
       if: failure()
       run: docker logs postfix-test

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,13 @@ RUN export DEBIAN_FRONTEND=noninteractive && apt-get update &&  \
     postfix-mysql  \
     postfix-policyd-spf-python \
     postsrsd \
+    rsyslog \
+    postgrey  \
+    spamassassin \
+    spamass-milter  \
+    opendmarc  \
+    opendkim  \
+    miltertest \
     supervisor  \
     netcat-traditional  \
     && \
@@ -17,6 +24,19 @@ RUN export DEBIAN_FRONTEND=noninteractive && apt-get update &&  \
     passwd -l vmail && \
     mkdir /srv/mail && \
     chown vmail:vmail /srv/mail
+# Milter-specific setup:
+# - Create per-user SpamAssassin database directory
+# - Add syslog user to debian-spamd group for spam database access
+#   (syslog has same uid as postfix, needed for milter socket permissions)
+# - Relax SpamAssassin date header rules to reduce false positives from automated senders
+RUN mkdir -p /vhome/users/ && \
+    chown -R debian-spamd:debian-spamd /vhome/users && \
+    usermod -aG debian-spamd syslog && \
+    echo "" >> /etc/spamassassin/local.cf && \
+    echo "# Disable strict Date header rules to allow emails from automated senders" >> /etc/spamassassin/local.cf && \
+    echo "score MISSING_DATE 0" >> /etc/spamassassin/local.cf && \
+    echo "score INVALID_DATE 0" >> /etc/spamassassin/local.cf
+
 # Beware that the vmail user has a dependency to the infrastructure repo
 # if you change the id information here, you will have to adapt the
 # infrastructure repo, too
@@ -28,7 +48,7 @@ EXPOSE 587
 EXPOSE 465
 EXPOSE 25
 
-VOLUME [ "/var/mail", "/var/spool/postfix", "/etc/postfix", "/etc/opendkim/keys" ]
+VOLUME [ "/var/mail", "/var/spool/postfix", "/etc/postfix", "/etc/opendkim/keys", "/vhome/users" ]
 
 COPY scripts/* /scripts/
 COPY configs/* /etc/


### PR DESCRIPTION
## Summary
- Install milter packages (rsyslog, postgrey, spamassassin, spamass-milter, opendmarc, opendkim, miltertest) in the Docker image
- Set up SpamAssassin per-user database directory (`/vhome/users`), group permissions, and relaxed date header rules
- Add `/vhome/users` to VOLUME declaration
- Add CI tests verifying all packages are installed and milter setup is correct

This is step 1 of merging [postfix-milters](https://github.com/nesono/postfix-milters) into this container. **No milter services are started** — Postfix behavior is completely unchanged. The packages are only installed and pre-configured.

## Test plan
- [x] Local Docker build succeeds
- [x] Container starts and Postfix/PostSRSd run normally (no regression)
- [x] All 7 milter packages verified as installed via `dpkg -l`
- [x] `/vhome/users` directory exists with correct ownership (`debian-spamd:debian-spamd`)
- [x] SpamAssassin `local.cf` contains relaxed date rules
- [ ] CI workflow passes (2 new test steps: package verification + milter setup verification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)