### PR TITLE
Add milter scripts from postfix-milters

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -84,6 +84,18 @@ jobs:
         docker exec postfix-test grep -q 'score INVALID_DATE 0' /etc/spamassassin/local.cf
         echo "Milter setup verified"
 
+    - name: Verify milter scripts are present and executable
+      run: |
+        for script in spamd.sh sa_learn.sh spamass.sh postgrey.sh opendkim.sh opendmarc.sh create_opendkim_conf.sh healthcheck.sh; do
+          docker exec postfix-test test -x /scripts/$script || { echo "FAIL: /scripts/$script not executable"; exit 1; }
+          echo "OK: /scripts/$script"
+        done
+        for spec in dkim_milter_test_spec.lua dmarc_milter_test_spec.lua spamass_milter_test_spec.lua; do
+          docker exec postfix-test test -f /scripts/$spec || { echo "FAIL: /scripts/$spec missing"; exit 1; }
+          echo "OK: /scripts/$spec"
+        done
+        echo "All milter scripts verified"
+
     - name: Show logs on failure
       if: failure()
       run: docker logs postfix-test

--- a/scripts/create_opendkim_conf.sh
+++ b/scripts/create_opendkim_conf.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -o errexit -o pipefail -o nounset
+
+# Script to create opendkim configuration using environment variable expansion
+
+# Files used in script
+readonly OPENDKIM_CONF="/etc/opendkim.conf"
+readonly SIGNING_TABLE="/etc/opendkim/SigningTable"
+readonly KEY_TABLE="/etc/opendkim/KeyTable"
+
+# Clean old files
+#rm -rf /etc/opendkim/*
+
+# Create /etc/opendkim.conf
+cat <<EOF > "${OPENDKIM_CONF}"
+Syslog			yes
+SyslogSuccess		yes
+#LogWhy			no
+
+# Common signing and verification parameters. In Debian, the "From" header is
+# oversigned, because it is often the identity key used by reputation systems
+# and thus somewhat security sensitive.
+Canonicalization	relaxed/simple
+#Mode			sv
+#SubDomains		no
+OversignHeaders		From
+
+KeyTable                refile:/etc/opendkim/KeyTable
+SigningTable            refile:/etc/opendkim/SigningTable
+
+# Keep in sync with postfix uid
+UserID			syslog
+UMask			007
+
+Socket			local:/var/spool/postfix/${DKIM_SOCKET_PATH}
+
+PidFile			/run/opendkim/opendkim.pid
+
+# The trust anchor enables DNSSEC. In Debian, the trust anchor file is provided
+# by the package dns-root-data.
+TrustAnchorFile		/usr/share/dns/root.key
+#Nameservers		127.0.0.1
+
+# If enabled, log verification stats here
+Statistics              /dev/stdout
+
+# KeyList is a file containing tuples of key information. Requires
+# KeyFile to be unset. Each line of the file should be of the format:
+#    sender glob:signing domain:signing key file
+# Blank lines and lines beginning with # are ignored. Selector will be
+# derived from the key's filename.
+#KeyList                /etc/dkim-keys.conf
+#
+# If true, when a signature verification fails and the signature included
+# a reporting request ("r=y") and the signing domain advertises a
+# reporting address (i.e. ra=user) in a reporting record in the DNS, the
+# filter will send a structured report to that address containing details
+# needed to reproduce the problem.
+# See RFC6651 for a complete description of this mechanism.
+SendReports             yes
+#
+# If enabled, will issue a Sendmail QUARANTINE for any messages that fail
+# signature verification, allowing them to be inspected later.
+#Quarantine             yes
+#
+# If enabled, will check for required headers when processing messages.
+# At a minimum, that means From: and Date: will be required. Messages not
+# containing the required headers will not be signed or verified, but will
+# be passed through
+RequiredHeaders        yes
+EOF
+
+# Clear KeyTable
+rm -rf "${KEY_TABLE}"
+# Fill KeyTable
+for domain in ${DKIM_DOMAINS//,/ }; do
+  echo "${DKIM_SELECTOR}._domainkey.${domain} ${domain}:${DKIM_SELECTOR}:${DKIM_KEY_PATH}" >> "${KEY_TABLE}"
+done
+
+# Clear SigningTable
+rm -rf "${SIGNING_TABLE}"
+# Fill SigningTable
+for domain in ${DKIM_DOMAINS//,/ }; do
+  echo "*@${domain} ${DKIM_SELECTOR}._domainkey.${domain}" >> "${SIGNING_TABLE}"
+done

--- a/scripts/dkim_milter_test_spec.lua
+++ b/scripts/dkim_milter_test_spec.lua
@@ -1,0 +1,24 @@
+--The script was taken from here and shortened: https://manpages.ubuntu.com/manpages/jammy/en/man8/miltertest.8.html
+
+socket_path = os.getenv("DKIM_SOCKET_PATH")
+if socket_path == nil then
+    mt.echo("DKIM_SOCKET_PATH not set. Skipping")
+    os.exit(0)
+end
+
+conn = mt.connect("unix:/var/spool/postfix/" .. socket_path)
+if conn == nil then
+    error "mt.connect() failed"
+end
+
+-- send connection information
+-- mt.negotiate() is called implicitly
+if mt.conninfo(conn, "localhost", "127.0.0.1") ~= nil then
+    error "mt.conninfo() failed"
+end
+if mt.getreply(conn) ~= SMFIR_CONTINUE then
+    error "mt.conninfo() unexpected reply"
+end
+
+-- wrap it up!
+mt.disconnect(conn, true)

--- a/scripts/dmarc_milter_test_spec.lua
+++ b/scripts/dmarc_milter_test_spec.lua
@@ -1,0 +1,25 @@
+--The script was taken from here and shortened: https://manpages.ubuntu.com/manpages/jammy/en/man8/miltertest.8.html
+
+socket_path = os.getenv("DMARC_SOCKET_PATH")
+if socket_path == nil then
+    mt.echo("DMARC_SOCKET_PATH not set. Skipping")
+    os.exit(0)
+end
+
+conn = mt.connect("unix:/var/spool/postfix/" .. socket_path)
+if conn == nil then
+    error "mt.connect() failed"
+end
+
+-- send connection information
+-- mt.negotiate() is called implicitly
+if mt.conninfo(conn, "localhost", "127.0.0.1") ~= nil then
+    error "mt.conninfo() failed"
+end
+reply = mt.getreply(conn)
+if reply ~= SMFIR_CONTINUE  and reply ~= SMFIR_ACCEPT then
+    error "mt.conninfo() unexpected reply"
+end
+
+-- wrap it up!
+mt.disconnect(conn, true)

--- a/scripts/healthcheck.sh
+++ b/scripts/healthcheck.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -o errexit -o pipefail -o nounset
+
+echo "Checking health of milters"
+# postgrey times out with any request, so we cannot check it
+miltertest -s /scripts/dkim_milter_test_spec.lua
+miltertest -s /scripts/dmarc_milter_test_spec.lua
+miltertest -s /scripts/spamass_milter_test_spec.lua

--- a/scripts/opendkim.sh
+++ b/scripts/opendkim.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -o errexit -o pipefail -o nounset
+
+cleanup() {
+  if [[ -n "${DKIM_SOCKET_PATH:-}" ]]; then rm -rf "/var/spool/postfix/${DKIM_SOCKET_PATH}"; fi
+}
+trap cleanup EXIT
+
+noop() {
+    while true; do
+        # 2147483647 = max signed 32-bit integer
+        # 2147483647 s ≅ 70 years
+        sleep infinity || sleep 2147483647
+    done
+}
+
+if [[ -n "${DKIM_SOCKET_PATH:-}" ]]; then
+  /usr/sbin/opendkim -f -x /etc/opendkim.conf  | \
+    while read -r line; do echo "opendkim: $line"; done
+else
+  echo "INFO: Not running opendkim, since no socket path is set"
+  noop
+fi

--- a/scripts/opendmarc.sh
+++ b/scripts/opendmarc.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -o errexit -o pipefail -o nounset
+
+cleanup() {
+  if [[ -n "${DMARC_SOCKET_PATH:-}" ]]; then rm -rf "/var/spool/postfix/${DMARC_SOCKET_PATH}"; fi
+}
+trap cleanup EXIT
+
+noop() {
+    while true; do
+        # 2147483647 = max signed 32-bit integer
+        # 2147483647 s ≅ 70 years
+        sleep infinity || sleep 2147483647
+    done
+}
+
+if [[ -n "${DMARC_SOCKET_PATH:-}" ]]; then
+  # Keep in sync with postfix uid
+  /usr/sbin/opendmarc -f -c /etc/opendmarc.conf -u syslog  | \
+    while read -r line; do echo "opendmarc: $line"; done
+else
+  echo "INFO: Not running opendmarc, since no socket path is set"
+  noop
+fi

--- a/scripts/postgrey.sh
+++ b/scripts/postgrey.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -o errexit -o pipefail -o nounset
+
+readonly POSTGREY_SOCKET="/var/spool/postfix/${POSTGREY_SOCKET_PATH:-}"
+
+cleanup() {
+  if [[ -n "${POSTGREY_SOCKET_PATH:-}" ]]; then rm -rf "${POSTGREY_SOCKET}"; fi
+}
+trap cleanup EXIT
+
+noop() {
+    while true; do
+        # 2147483647 = max signed 32-bit integer
+        # 2147483647 s ≅ 70 years
+        sleep infinity || sleep 2147483647
+    done
+}
+
+if [[ -n "${POSTGREY_SOCKET_PATH:-}" ]]; then
+  /usr/sbin/postgrey --unix="${POSTGREY_SOCKET}" | \
+    while read -r line; do echo "postgrey: $line"; done
+else
+  echo "INFO: Not running postgrey, since no socket path is set"
+  noop
+fi

--- a/scripts/sa_learn.sh
+++ b/scripts/sa_learn.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+set -o errexit -o pipefail -o nounset
+
+# script to create a directory under /vhome/users for each mail account,
+# populate the spam db with sa-learn, and fix the permissions of the dir.
+
+while true; do
+  # get all mail accounts
+  echo "sa_learn: Learning Spam from user folders"
+  if [[ -n "$(ls -A /var/mail/ 2>/dev/null)" ]]; then
+    for dir in /var/mail/*; do
+      mailaccount="${dir##*/}"
+      echo "sa_learn: Creating dir for ${mailaccount}"
+      spamdbpath="/vhome/users/${mailaccount}/spamassassin/"
+      mkdir -p "${spamdbpath}"
+
+      junkfolder="${dir}/.Junk"
+      if [ -d "${junkfolder}" ]; then
+        echo "sa_learn: Learning Spam from ${junkfolder} for user ${mailaccount}"
+        sa-learn --spam --dbpath "${spamdbpath}/bayes" "${junkfolder}" | \
+          while read line; do echo "sa_learn: $line"; done
+        sa-learn --sync | \
+          while read line; do echo "sa_learn: $line"; done
+      else
+        echo "sa_learn: No Junk folder found - skipping"
+      fi
+
+      hamfolder="${dir}/.Ham"
+      if [ -d "${hamfolder}" ]; then
+        echo "sa_learn: Learning Ham from ${hamfolder} for user ${mailaccount}"
+        sa-learn --ham --dbpath "${spamdbpath}/bayes" --progress "${hamfolder}" | \
+          while read line; do echo "sa_learn: $line"; done
+        sa-learn --sync | \
+          while read line; do echo "sa_learn: $line"; done
+      else
+        echo "sa_learn: No Archive folder found - skipping"
+      fi
+    done
+  else
+    echo "sa_learn: No accounts found! Skipping user learning"
+  fi
+
+  echo "sa_learn: Running the Spamassassin Cronjob"
+  /etc/cron.daily/spamassassin
+
+  echo "sa_learn: Sleeping for a day"
+  sleep 86400
+done

--- a/scripts/spamass.sh
+++ b/scripts/spamass.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -o errexit -o pipefail -o nounset
+
+readonly SPAMASS_SOCKET="/var/spool/postfix/${SPAMASS_SOCKET_PATH:-}"
+
+cleanup() {
+  if [[ -n "${SPAMASS_SOCKET_PATH:-}" ]]; then rm -rf "${SPAMASS_SOCKET}"; fi
+}
+trap cleanup EXIT
+
+noop() {
+    while true; do
+        # 2147483647 = max signed 32-bit integer
+        # 2147483647 s ≅ 70 years
+        sleep infinity || sleep 2147483647
+    done
+}
+
+if [[ -n "${SPAMASS_SOCKET_PATH:-}" ]]; then
+  /usr/sbin/spamass-milter -r 15 -p "${SPAMASS_SOCKET}" | \
+    while read -r line; do echo "spamass-milter: $line"; done
+else
+  echo "INFO: Not running spamass-milter, since no socket path is set"
+  noop
+fi

--- a/scripts/spamass_milter_test_spec.lua
+++ b/scripts/spamass_milter_test_spec.lua
@@ -1,0 +1,100 @@
+--The script was taken from here and shortened: https://manpages.ubuntu.com/manpages/jammy/en/man8/miltertest.8.html
+
+socket_path = os.getenv("SPAMASS_SOCKET_PATH")
+if socket_path == nil then
+    mt.echo("SPAMASS_SOCKET_PATH not set. Skipping")
+    os.exit(0)
+end
+
+conn = mt.connect("unix:/var/spool/postfix/" .. socket_path)
+if conn == nil then
+    error "mt.connect() failed"
+end
+
+-- send connection information
+-- mt.negotiate() is called implicitly
+if mt.conninfo(conn, "localhost", "127.0.0.1") ~= nil then
+    error "mt.conninfo() failed"
+end
+reply = mt.getreply(conn)
+if reply ~= SMFIR_CONTINUE  and reply ~= SMFIR_ACCEPT then
+    error "mt.conninfo() unexpected reply"
+end
+
+-- send envelope macros and sender data
+-- mt.helo() is called implicitly
+mt.macro(conn, SMFIC_MAIL, "i", "test-id")
+if mt.mailfrom(conn, "user@example.com") ~= nil then
+    error "mt.mailfrom() failed"
+end
+if mt.getreply(conn) ~= SMFIR_CONTINUE then
+    error "mt.mailfrom() unexpected reply"
+end
+
+-- send headers
+-- mt.rcptto() is called implicitly
+if mt.header(conn, "From", "user@example.com") ~= nil then
+    error "mt.header(From) failed"
+end
+if mt.getreply(conn) ~= SMFIR_CONTINUE then
+    error "mt.header(From) unexpected reply"
+end
+if mt.header(conn, "Date", os.date("%a, %d %b %Y %H:%M:%S %z")) ~= nil then
+    error "mt.header(Date) failed"
+end
+if mt.getreply(conn) ~= SMFIR_CONTINUE then
+    error "mt.header(Date) unexpected reply"
+end
+if mt.header(conn, "Received", "from mail-vs1-f71.google.com (mail-vs1-f71.google.com\n" ..
+        "    [209.85.217.71]) (Using TLS) by relay.mimecast.com with ESMTP id\n" ..
+        "    us-mta-152-adtPER30NqGkJJmUbRyRBg-1; " ..
+        os.date("%a, %d %b %Y %H:%M:%S %z")) ~= nil then
+    error "mt.header(Received) failed"
+end
+if mt.getreply(conn) ~= SMFIR_CONTINUE then
+    error "mt.header(Received) unexpected reply"
+end
+if mt.header(conn, "Message-ID", "<MQDQEagfJkw=eD8BSjVKY_PdAG=0cLzqn76ViD8r2AVNdqnax0w@mail.gmail.com>") ~= nil then
+    error "mt.header(Message-ID) failed"
+end
+if mt.getreply(conn) ~= SMFIR_CONTINUE then
+    error "mt.header(Message-ID) unexpected reply"
+end
+if mt.header(conn, "Subject", "Milter test") ~= nil then
+    error "mt.header(Subject) failed"
+end
+if mt.getreply(conn) ~= SMFIR_CONTINUE then
+    error "mt.header(Subject) unexpected reply"
+end
+if mt.header(conn, "To", "user@example.com") ~= nil then
+    error "mt.header(To) failed"
+end
+if mt.getreply(conn) ~= SMFIR_CONTINUE then
+    error "mt.header(To) unexpected reply"
+end
+-- send EOH
+if mt.eoh(conn) ~= nil then
+    error "mt.eoh() failed"
+end
+if mt.getreply(conn) ~= SMFIR_CONTINUE then
+    error "mt.eoh() unexpected reply"
+end
+
+-- send body
+if mt.bodystring(conn, "This is a test!\r\n") ~= nil then
+    error "mt.bodystring() failed"
+end
+if mt.getreply(conn) ~= SMFIR_CONTINUE then
+    error "mt.bodystring() unexpected reply"
+end
+-- end of message; let the filter react
+if mt.eom(conn) ~= nil then
+    error "mt.eom() failed"
+end
+reply = mt.getreply(conn)
+if reply ~= SMFIR_ACCEPT and reply ~= SMFIR_CONTINUE then
+    error "mt.eom() unexpected reply"
+end
+
+-- wrap it up!
+mt.disconnect(conn, true)

--- a/scripts/spamd.sh
+++ b/scripts/spamd.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -o errexit -o pipefail -o nounset
+
+test -f /etc/default/spamassassin && . /etc/default/spamassassin | while read -r line; do echo "spamd: $line"; done
+
+noop() {
+    while true; do
+        # 2147483647 = max signed 32-bit integer
+        # 2147483647 s ≅ 70 years
+        sleep infinity || sleep 2147483647
+    done
+}
+
+if [[ -n "${SPAMASS_SOCKET_PATH:-}" ]]; then
+  # Taken from /etc/init.d/spamassassin, including the comment below
+  export TMPDIR=/tmp
+  # Apparently people have trouble if this isn't explicitly set...
+  /usr/sbin/spamd --max-children=5 -u debian-spamd --virtual-config-dir=/vhome/users/%u/spamassassin  | \
+    while read -r line; do echo "spamd: $line"; done
+else
+  echo "INFO: Not running Spamd, since no socket path for spamass is set"
+  noop
+fi


### PR DESCRIPTION
## Summary
- Copy 11 milter scripts from [postfix-milters](https://github.com/nesono/postfix-milters): 6 service wrappers (spamd, sa_learn, spamass, postgrey, opendkim, opendmarc), DKIM config generator, healthcheck, and 3 miltertest Lua specs
- Add CI test verifying all scripts are present and executable in the container

This is step 2 of merging postfix-milters into this container. **No services are started yet** — scripts are only placed in `/scripts/`. Postfix behavior is unchanged.

## Test plan
- [x] Local Docker build succeeds
- [x] Container starts and Postfix/PostSRSd run normally (no regression)
- [x] All 11 scripts verified present and executable in container
- [ ] CI workflow passes (new test step: script presence verification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)