### PR TITLE
Add milter services to supervisord

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -96,6 +96,13 @@ jobs:
         done
         echo "All milter scripts verified"
 
+    - name: Verify milter services are managed by supervisor
+      run: |
+        for svc in rsyslog spamd sa_learn postgrey spamass opendkim opendmarc; do
+          docker exec postfix-test supervisorctl -c /etc/supervisord.conf status $svc
+        done
+        echo "All milter services registered in supervisor"
+
     - name: Show logs on failure
       if: failure()
       run: docker logs postfix-test

--- a/configs/supervisord.conf
+++ b/configs/supervisord.conf
@@ -35,3 +35,87 @@ stdout_logfile  = /dev/stdout
 stderr_logfile  = /dev/stderr
 stdout_logfile_maxbytes = 0
 stderr_logfile_maxbytes = 0
+
+[program:rsyslog]
+command         = rsyslogd -n
+priority        = 0
+autostart       = true
+autorestart     = true
+startsecs       = 2
+stopwaitsecs    = 2
+stdout_logfile  = /dev/stdout
+stderr_logfile  = /dev/stderr
+stdout_logfile_maxbytes = 0
+stderr_logfile_maxbytes = 0
+
+[program:spamd]
+command         = /scripts/spamd.sh
+priority        = 10
+autostart       = true
+autorestart     = true
+startsecs       = 5
+stopwaitsecs    = 5
+stdout_logfile  = /dev/stdout
+stderr_logfile  = /dev/stderr
+stdout_logfile_maxbytes = 0
+stderr_logfile_maxbytes = 0
+
+[program:sa_learn]
+command         = /scripts/sa_learn.sh
+priority        = 10
+autostart       = true
+autorestart     = true
+startsecs       = 5
+stopwaitsecs    = 5
+stdout_logfile  = /dev/stdout
+stderr_logfile  = /dev/stderr
+stdout_logfile_maxbytes = 0
+stderr_logfile_maxbytes = 0
+
+[program:postgrey]
+command         = /scripts/postgrey.sh
+autostart       = true
+autorestart     = true
+startsecs       = 5
+stopwaitsecs    = 5
+stdout_logfile  = /dev/stdout
+stderr_logfile  = /dev/stderr
+stdout_logfile_maxbytes = 0
+stderr_logfile_maxbytes = 0
+
+[program:spamass]
+command         = /scripts/spamass.sh
+# Keep in sync with postfix user id
+user            = syslog
+autostart       = true
+autorestart     = true
+startsecs       = 5
+stopwaitsecs    = 5
+stdout_logfile  = /dev/stdout
+stderr_logfile  = /dev/stderr
+stdout_logfile_maxbytes = 0
+stderr_logfile_maxbytes = 0
+
+[program:opendkim]
+command         = /scripts/opendkim.sh
+# Keep in sync with postfix user id
+user            = syslog
+autostart       = true
+autorestart     = true
+startsecs       = 5
+stopwaitsecs    = 5
+stdout_logfile  = /dev/stdout
+stderr_logfile  = /dev/stderr
+stdout_logfile_maxbytes = 0
+stderr_logfile_maxbytes = 0
+
+[program:opendmarc]
+command         = /scripts/opendmarc.sh
+autostart       = true
+autorestart     = true
+startsecs       = 5
+stopwaitsecs    = 5
+stdout_logfile  = /dev/stdout
+stderr_logfile  = /dev/stderr
+stdout_logfile_maxbytes = 0
+stderr_logfile_maxbytes = 0


### PR DESCRIPTION
## Summary
- Register 7 milter services in supervisord.conf: rsyslog (priority 0), spamd, sa_learn, postgrey, spamass, opendkim, opendmarc
- All services auto-restart on failure and log to stdout/stderr
- spamass and opendkim run as `syslog` user (UID sync with postfix)
- Add CI test verifying all services are registered and managed by supervisor

This is step 3 of merging postfix-milters into this container. **All milter services noop** when their socket environment variables are unset, so Postfix behavior is unchanged in the default configuration.

## Test plan
- [x] Local Docker build succeeds
- [x] All 9 supervisor services show up in `supervisorctl status`
- [x] Postfix and PostSRSd still run normally
- [x] SMTP responds on port 25
- [x] CI workflow passes (new test step: supervisor service verification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)