### PR TITLE
Add milter initialization to run.sh

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -110,3 +110,111 @@ jobs:
     - name: Cleanup
       if: always()
       run: docker rm -f postfix-test || true
+
+  milter-smoke-test:
+
+    runs-on: ubuntu-latest
+    needs: build-and-smoke-test
+
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Build the Docker image
+      run: docker build . --file Dockerfile --tag postfix-milter-test
+
+    - name: Create dummy credential and DKIM key files
+      run: |
+        echo "testuser" > /tmp/sql_user.txt
+        echo "testpass" > /tmp/sql_password.txt
+        mkdir -p /tmp/dkim-keys
+        openssl genrsa -out /tmp/dkim-keys/mail.private 2048 2>/dev/null
+
+    - name: Start container with milters enabled
+      run: |
+        docker run -d --name milter-test \
+          -e MYHOSTNAME=mail.example.com \
+          -e MYNETWORKS="127.0.0.0/8" \
+          -e SQL_USER_FILE=/tmp/sql_user.txt \
+          -e SQL_PASSWORD_FILE=/tmp/sql_password.txt \
+          -e SQL_HOST=127.0.0.1 \
+          -e SQL_DB_NAME=postfix \
+          -e SPAMHAUS_DISABLE=1 \
+          -e POSTGREY_SOCKET_PATH=private/postgrey \
+          -e SPAMASS_SOCKET_PATH=private/spamass \
+          -e DKIM_SOCKET_PATH=private/opendkim \
+          -e DKIM_DOMAINS=example.com \
+          -e DKIM_SELECTOR=mail \
+          -e DKIM_KEY_PATH=/etc/opendkim/keys/mail.private \
+          -e DMARC_SOCKET_PATH=private/opendmarc \
+          -e MAIL_HOSTNAME=mail.example.com \
+          -v /tmp/sql_user.txt:/tmp/sql_user.txt:ro \
+          -v /tmp/sql_password.txt:/tmp/sql_password.txt:ro \
+          -v /tmp/dkim-keys:/etc/opendkim/keys:ro \
+          -p 2526:25 \
+          postfix-milter-test
+
+    - name: Wait for services to start
+      run: |
+        for i in $(seq 1 30); do
+          if docker exec milter-test supervisorctl -c /etc/supervisord.conf status | grep -q RUNNING; then
+            echo "Services started after ${i}s"
+            break
+          fi
+          sleep 1
+        done
+
+    - name: Verify all services are running
+      run: |
+        sleep 10
+        docker exec milter-test supervisorctl -c /etc/supervisord.conf status
+        for svc in postfix postsrs rsyslog spamd sa_learn postgrey spamass opendkim opendmarc; do
+          status=$(docker exec milter-test supervisorctl -c /etc/supervisord.conf status $svc | awk '{print $2}')
+          echo "$svc: $status"
+          if [[ "$status" != "RUNNING" ]]; then
+            echo "FAIL: $svc is not RUNNING (status: $status)"
+            exit 1
+          fi
+        done
+        echo "All services running"
+
+    - name: Verify SMTP responds on port 25
+      run: |
+        response=$(docker exec milter-test bash -c 'echo QUIT | nc -w 5 127.0.0.1 25')
+        echo "$response"
+        echo "$response" | grep -q "220"
+
+    - name: Verify milter socket directories exist with correct ownership
+      run: |
+        docker exec milter-test stat -c '%U:%G' /var/spool/postfix/private | grep -q 'syslog:opendkim'
+        echo "Socket directory ownership verified"
+
+    - name: Verify OpenDKIM config was generated
+      run: |
+        docker exec milter-test test -f /etc/opendkim.conf
+        docker exec milter-test grep -q 'example.com' /etc/opendkim/KeyTable
+        docker exec milter-test grep -q 'example.com' /etc/opendkim/SigningTable
+        echo "OpenDKIM config verified"
+
+    - name: Verify OpenDMARC config was patched
+      run: |
+        docker exec milter-test grep -q 'Socket local:/var/spool/postfix/private/opendmarc' /etc/opendmarc.conf
+        docker exec milter-test grep -q 'TrustedAuthservIDs mail.example.com' /etc/opendmarc.conf
+        echo "OpenDMARC config verified"
+
+    - name: Verify rsyslog imklog is disabled
+      run: |
+        docker exec milter-test grep -q '^#module(load="imklog' /etc/rsyslog.conf
+        echo "rsyslog imklog disabled"
+
+    - name: Verify postfix is in opendkim group
+      run: |
+        docker exec milter-test id postfix | grep -q opendkim
+        echo "postfix user is in opendkim group"
+
+    - name: Show logs on failure
+      if: failure()
+      run: docker logs milter-test
+
+    - name: Cleanup
+      if: always()
+      run: docker rm -f milter-test || true

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && apt-get update &&  \
     postsrsd \
     rsyslog \
     postgrey  \
+    spamd \
     spamassassin \
     spamass-milter  \
     opendmarc  \

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -212,5 +212,70 @@ fi
 # run the postfix instance configuration taken from the /etc/init.d/postfix script
 /usr/lib/postfix/configure-instance.sh
 
+# --- Milter initialization (merged from postfix-milters) ---
+
+# Patch rsyslogd to disable kernel message logging
+sed 's/^module(load=\"imklog\".*)/#&/' -i.bak /etc/rsyslog.conf
+
+# Validate and log milter socket paths
+if [[ -n "${POSTGREY_SOCKET_PATH:-}" ]]; then
+  echo "Postgrey socket path set: ${POSTGREY_SOCKET_PATH}"
+fi
+if [[ -n "${SPAMASS_SOCKET_PATH:-}" ]]; then
+  echo "Spamass socket path set: ${SPAMASS_SOCKET_PATH}"
+fi
+if [[ -n "${DKIM_SOCKET_PATH:-}" ]]; then
+  echo "DKIM socket path set: ${DKIM_SOCKET_PATH}"
+  if [[ -z "${DKIM_DOMAINS:-}" ]]; then (>&2 echo "Error: env var DKIM_DOMAINS not set" && exit 1); fi
+  if [[ -z "${DKIM_SELECTOR:-}" ]]; then (>&2 echo "Error: env var DKIM_SELECTOR not set" && exit 1); fi
+  if [[ -z "${DKIM_KEY_PATH:-}" ]]; then (>&2 echo "Error: env var DKIM_KEY_PATH not set" && exit 1); fi
+
+  # Create opendkim.conf from template
+  /scripts/create_opendkim_conf.sh
+fi
+
+# Patch /etc/opendmarc.conf
+if [[ -n "${DMARC_SOCKET_PATH:-}" ]]; then
+  echo "DMARC socket path is set: ${DMARC_SOCKET_PATH}"
+  if [[ -z "${MAIL_HOSTNAME:-}" ]]; then (>&2 echo "Error: env var MAIL_HOSTNAME not set" && exit 1); fi
+
+  # Configuration taken from https://www.linuxbabe.com/mail-server/opendmarc-postfix-ubuntu
+  sed 's@^Socket local:.*@Socket local:/var/spool/postfix/'"${DMARC_SOCKET_PATH}"'@' -i.bak /etc/opendmarc.conf
+  cat <<EOF >> /etc/opendmarc.conf
+AuthservID OpenDMARC
+TrustedAuthservIDs ${MAIL_HOSTNAME}
+RejectFailures true
+IgnoreAuthenticatedClients true
+RequiredHeaders    true
+SPFSelfValidate true
+EOF
+fi
+
+# Ensuring the directories for the sockets exist (usually not necessary in prod)
+if [[ -n "${POSTGREY_SOCKET_PATH:-}" ]]; then mkdir -p /var/spool/postfix/"${POSTGREY_SOCKET_PATH%/*}"; fi
+if [[ -n "${SPAMASS_SOCKET_PATH:-}" ]]; then mkdir -p /var/spool/postfix/"${SPAMASS_SOCKET_PATH%/*}"; fi
+if [[ -n "${DKIM_SOCKET_PATH:-}" ]]; then mkdir -p /var/spool/postfix/"${DKIM_SOCKET_PATH%/*}"; fi
+if [[ -n "${DMARC_SOCKET_PATH:-}" ]]; then mkdir -p /var/spool/postfix/"${DMARC_SOCKET_PATH%/*}"; fi
+
+# Fix ownership for milter socket directories and SpamAssassin
+# Milter processes (syslog user) create unix sockets inside /var/spool/postfix/private/.
+# Postfix requires /var/spool/postfix/private to be owned by postfix.
+# We set the group to opendkim and make it group-writable so milter processes can
+# create sockets there. Both syslog and postfix are added to opendkim group.
+usermod -aG opendkim postfix
+usermod -aG opendkim syslog
+# Collect unique socket parent directories and fix their permissions
+declare -A SOCKET_DIRS
+for path in "${POSTGREY_SOCKET_PATH:-}" "${SPAMASS_SOCKET_PATH:-}" "${DKIM_SOCKET_PATH:-}" "${DMARC_SOCKET_PATH:-}"; do
+  if [[ -n "${path}" ]]; then
+    SOCKET_DIRS["/var/spool/postfix/${path%/*}"]=1
+  fi
+done
+for dir in "${!SOCKET_DIRS[@]}"; do
+  chown postfix:opendkim "${dir}"
+  chmod 775 "${dir}"
+done
+chown -R debian-spamd:debian-spamd /var/lib/spamass-milter
+
 echo_exec_banner
 exec supervisord -c /etc/supervisord.conf


### PR DESCRIPTION
## Summary
- Integrate milter initialization logic from postfix-milters into `run.sh`: rsyslog patching, OpenDKIM config generation, OpenDMARC config patching, socket directory creation, and permission fixes
- Add `spamd` package to Dockerfile (split from `spamassassin` in Ubuntu 24.04)
- Handle UID/GID differences: use `postfix:opendkim` ownership with 775 perms on socket dirs so both postfix and milter processes can access sockets
- Add dedicated `milter-smoke-test` CI job that starts the container with all milter env vars enabled and verifies:
  - All 9 supervisor services reach RUNNING state
  - SMTP responds on port 25
  - Socket directory permissions are correct
  - OpenDKIM KeyTable/SigningTable are generated
  - OpenDMARC config is patched with correct socket path and hostname
  - rsyslog imklog is disabled
  - postfix user is in the opendkim group

**This is the key step** — after merging, you can pass milter env vars directly to this container and remove the separate postfix-milters container from your docker-compose.

## Test plan
- [x] Local build succeeds
- [x] All 9 services RUNNING with milter env vars set
- [x] All 9 services RUNNING without milter env vars (backward compat)
- [x] SMTP responds on port 25 in both modes
- [x] OpenDKIM/OpenDMARC configs generated correctly
- [x] Socket directory permissions allow both postfix and milter access
- [ ] CI: existing `build-and-smoke-test` passes (no milter env vars)
- [ ] CI: new `milter-smoke-test` passes (all milter env vars)

🤖 Generated with [Claude Code](https://claude.com/claude-code)