### PR TITLE
Fix entrypoint idempotency: prevent master.cf duplication on restart

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -122,7 +122,7 @@ jobs:
           postfix-smoke-test
         sleep 5
         # Save counts after first start
-        MASTER_LINES_1=$(docker exec idem-test wc -l < /etc/postfix/master.cf)
+        MASTER_LINES_1=$(docker exec idem-test bash -c 'wc -l < /etc/postfix/master.cf')
         XCLIENT_1=$(docker exec idem-test grep -c smtpd_authorized_xclient_hosts /etc/postfix/master.cf)
         SPF_1=$(docker exec idem-test grep -c '^policyd-spf' /etc/postfix/master.cf)
         SMTPS_1=$(docker exec idem-test grep -c '^smtps' /etc/postfix/master.cf)
@@ -131,7 +131,7 @@ jobs:
         docker restart idem-test
         sleep 5
         # Compare counts after restart
-        MASTER_LINES_2=$(docker exec idem-test wc -l < /etc/postfix/master.cf)
+        MASTER_LINES_2=$(docker exec idem-test bash -c 'wc -l < /etc/postfix/master.cf')
         XCLIENT_2=$(docker exec idem-test grep -c smtpd_authorized_xclient_hosts /etc/postfix/master.cf)
         SPF_2=$(docker exec idem-test grep -c '^policyd-spf' /etc/postfix/master.cf)
         SMTPS_2=$(docker exec idem-test grep -c '^smtps' /etc/postfix/master.cf)

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -103,10 +103,58 @@ jobs:
         done
         echo "All milter services registered in supervisor"
 
+    - name: Verify entrypoint is idempotent (master.cf not mangled on restart)
+      run: |
+        docker rm -f idem-test 2>/dev/null || true
+        docker run -d --name idem-test \
+          -e MYHOSTNAME=mail.example.com \
+          -e MYNETWORKS="127.0.0.0/8" \
+          -e SQL_USER_FILE=/tmp/sql_user.txt \
+          -e SQL_PASSWORD_FILE=/tmp/sql_password.txt \
+          -e SQL_HOST=127.0.0.1 \
+          -e SQL_DB_NAME=postfix \
+          -e SPAMHAUS_DISABLE=1 \
+          -e SPF_ENABLE=1 \
+          -e SMTPS_ENABLE=1 \
+          -e AUTHORIZED_SMTPD_XCLIENT_HOSTS=172.20.0.1 \
+          -v /tmp/sql_user.txt:/tmp/sql_user.txt:ro \
+          -v /tmp/sql_password.txt:/tmp/sql_password.txt:ro \
+          postfix-smoke-test
+        sleep 5
+        # Save counts after first start
+        MASTER_LINES_1=$(docker exec idem-test wc -l < /etc/postfix/master.cf)
+        XCLIENT_1=$(docker exec idem-test grep -c smtpd_authorized_xclient_hosts /etc/postfix/master.cf)
+        SPF_1=$(docker exec idem-test grep -c '^policyd-spf' /etc/postfix/master.cf)
+        SMTPS_1=$(docker exec idem-test grep -c '^smtps' /etc/postfix/master.cf)
+        SRS_1=$(docker exec idem-test grep -c 'SRS_DOMAIN' /etc/default/postsrsd)
+        # Restart container (re-runs entrypoint)
+        docker restart idem-test
+        sleep 5
+        # Compare counts after restart
+        MASTER_LINES_2=$(docker exec idem-test wc -l < /etc/postfix/master.cf)
+        XCLIENT_2=$(docker exec idem-test grep -c smtpd_authorized_xclient_hosts /etc/postfix/master.cf)
+        SPF_2=$(docker exec idem-test grep -c '^policyd-spf' /etc/postfix/master.cf)
+        SMTPS_2=$(docker exec idem-test grep -c '^smtps' /etc/postfix/master.cf)
+        SRS_2=$(docker exec idem-test grep -c 'SRS_DOMAIN' /etc/default/postsrsd)
+        echo "master.cf lines: $MASTER_LINES_1 -> $MASTER_LINES_2"
+        echo "xclient: $XCLIENT_1 -> $XCLIENT_2"
+        echo "policyd-spf: $SPF_1 -> $SPF_2"
+        echo "smtps: $SMTPS_1 -> $SMTPS_2"
+        echo "SRS_DOMAIN: $SRS_1 -> $SRS_2"
+        [[ "$MASTER_LINES_1" == "$MASTER_LINES_2" ]] || { echo "FAIL: master.cf grew after restart"; exit 1; }
+        [[ "$XCLIENT_1" == "$XCLIENT_2" ]] || { echo "FAIL: xclient lines duplicated"; exit 1; }
+        [[ "$SPF_1" == "$SPF_2" ]] || { echo "FAIL: policyd-spf duplicated"; exit 1; }
+        [[ "$SMTPS_1" == "$SMTPS_2" ]] || { echo "FAIL: smtps duplicated"; exit 1; }
+        [[ "$SRS_1" == "$SRS_2" ]] || { echo "FAIL: SRS_DOMAIN duplicated"; exit 1; }
+        echo "Idempotency verified"
+        docker rm -f idem-test
+
     - name: Show logs on failure
       if: failure()
       run: docker logs postfix-test
 
     - name: Cleanup
       if: always()
-      run: docker rm -f postfix-test || true
+      run: |
+        docker rm -f postfix-test || true
+        docker rm -f idem-test || true

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -12,7 +12,9 @@ if [[ -z "${MYHOSTNAME:-}" ]]; then (>&2 echo "Error: env var MYHOSTNAME not set
 if [[ -z "${MYNETWORKS:-}" ]]; then (>&2 echo "Error: env var MYNETWORKS not set" && exit 1); fi
 
 # patch SRS configuration (postsrsd v1 on Ubuntu 24.04 uses /etc/default/postsrsd)
-echo "SRS_DOMAIN=${MYHOSTNAME}" >> /etc/default/postsrsd
+if ! grep -q "^SRS_DOMAIN=" /etc/default/postsrsd; then
+  echo "SRS_DOMAIN=${MYHOSTNAME}" >> /etc/default/postsrsd
+fi
 
 do_postconf -e "myhostname=${MYHOSTNAME}"
 do_postconf -e "mynetworks=${MYNETWORKS}"
@@ -77,21 +79,29 @@ if [[ -n "${SPF_ENABLE:-}" ]]; then
   fi
   RCP_RESTR="${RCP_RESTR:+$RCP_RESTR,}check_policy_service unix:private/policyd-spf"
   do_postconf -e 'policyd-spf_time_limit=3600'
-  cat <<EOF >> /etc/postfix/master.cf
+  if ! grep -q '^policyd-spf' /etc/postfix/master.cf; then
+    cat <<EOF >> /etc/postfix/master.cf
 policyd-spf  unix  -       n       n       -       0       spawn
     user=policyd-spf argv=/usr/bin/policyd-spf
 EOF
+  fi
 fi
 
 
 if [[ -n "${SMTPS_ENABLE:-}" ]]; then
-  cat <<EOF >> /etc/postfix/master.cf
+  if ! grep -q '^smtps' /etc/postfix/master.cf; then
+    if [[ -n "${AUTHORIZED_SMTPD_XCLIENT_HOSTS:-}" ]]; then
+      cat <<EOF >> /etc/postfix/master.cf
+smtps     inet  n       -       -       -       -       smtpd
+  -o smtpd_tls_wrappermode=yes
+  -o smtpd_authorized_xclient_hosts=${AUTHORIZED_SMTPD_XCLIENT_HOSTS}
+EOF
+    else
+      cat <<EOF >> /etc/postfix/master.cf
 smtps     inet  n       -       -       -       -       smtpd
   -o smtpd_tls_wrappermode=yes
 EOF
-  # Patch the smtp line to allow xclient from specific hosts - smtps version
-  if [[ -n "${AUTHORIZED_SMTPD_XCLIENT_HOSTS:-}" ]]; then
-    echo "  -o smtpd_authorized_xclient_hosts=${AUTHORIZED_SMTPD_XCLIENT_HOSTS}" >> /etc/postfix/master.cf
+    fi
   fi
 fi
 
@@ -195,18 +205,17 @@ fi
 
 
 # Patch the smtp and submission lines to allow xclient from specific hosts
+# This is idempotent: only adds the -o line if not already present after the service line
 if [[ -n "${AUTHORIZED_SMTPD_XCLIENT_HOSTS:-}" ]]; then
+  XCLIENT_OPT="  -o smtpd_authorized_xclient_hosts=${AUTHORIZED_SMTPD_XCLIENT_HOSTS}"
   # smtp line
-  SMTP_LINE=$(cat /etc/postfix/master.cf | grep "^smtp\s\+inet")
-  sed -i "s|^$SMTP_LINE|# $SMTP_LINE|" /etc/postfix/master.cf
-  echo "$SMTP_LINE" >> /etc/postfix/master.cf
-  echo "  -o smtpd_authorized_xclient_hosts=${AUTHORIZED_SMTPD_XCLIENT_HOSTS}" >> /etc/postfix/master.cf
-
+  if ! grep -q 'smtpd_authorized_xclient_hosts' <(grep -A1 '^smtp\s\+inet' /etc/postfix/master.cf); then
+    sed -i "/^smtp\s\+inet/a\\${XCLIENT_OPT}" /etc/postfix/master.cf
+  fi
   # submission line
-  SUBMISSION_LINE=$(cat /etc/postfix/master.cf | grep "^submission\s\+inet")
-  sed -i "s|^$SUBMISSION_LINE|# $SUBMISSION_LINE|" /etc/postfix/master.cf
-  echo "$SUBMISSION_LINE" >> /etc/postfix/master.cf
-  echo "  -o smtpd_authorized_xclient_hosts=${AUTHORIZED_SMTPD_XCLIENT_HOSTS}" >> /etc/postfix/master.cf
+  if ! grep -q 'smtpd_authorized_xclient_hosts' <(grep -A1 '^submission\s\+inet' /etc/postfix/master.cf); then
+    sed -i "/^submission\s\+inet/a\\${XCLIENT_OPT}" /etc/postfix/master.cf
+  fi
 fi
 
 # run the postfix instance configuration taken from the /etc/init.d/postfix script


### PR DESCRIPTION
## Summary
- Fix all `master.cf` and `postsrsd` append operations to be idempotent (check before writing)
- **SPF**: guard `policyd-spf` append with `grep -q '^policyd-spf'`
- **SMTPS**: guard `smtps` block with `grep -q '^smtps'`, include xclient in initial block creation
- **XCLIENT** (smtp/submission): replace comment-out-and-re-append with `sed` insert-after, guarded by existing xclient check
- **SRS_DOMAIN**: guard with `grep -q '^SRS_DOMAIN='`
- Add CI test that starts a container, restarts it, and verifies `master.cf` line count and all key entry counts are unchanged

## Root cause
The entrypoint used `echo >> /etc/postfix/master.cf` and `cat <<EOF >>` without checking if entries already existed. On container restart (which re-runs the entrypoint), these operations duplicated lines, eventually mangling postfix configuration and preventing it from starting.

## Test plan
- [x] Local build succeeds
- [x] First start produces correct `master.cf` with SPF, SMTPS, and XCLIENT
- [x] Simulated restart: all counts identical (0 duplicates)
- [x] Second simulated restart: still identical
- [x] SMTP responds on port 25 after restart
- [ ] CI: new idempotency test (start → restart → compare counts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)