### PR TITLE
Fix sa_learn crash when no new tokens to learn

### DIFF
--- a/scripts/sa_learn.sh
+++ b/scripts/sa_learn.sh
@@ -18,9 +18,9 @@ while true; do
       if [ -d "${junkfolder}" ]; then
         echo "sa_learn: Learning Spam from ${junkfolder} for user ${mailaccount}"
         sa-learn --spam --dbpath "${spamdbpath}/bayes" "${junkfolder}" | \
-          while read line; do echo "sa_learn: $line"; done
+          while read line; do echo "sa_learn: $line"; done || true
         sa-learn --sync | \
-          while read line; do echo "sa_learn: $line"; done
+          while read line; do echo "sa_learn: $line"; done || true
       else
         echo "sa_learn: No Junk folder found - skipping"
       fi
@@ -29,9 +29,9 @@ while true; do
       if [ -d "${hamfolder}" ]; then
         echo "sa_learn: Learning Ham from ${hamfolder} for user ${mailaccount}"
         sa-learn --ham --dbpath "${spamdbpath}/bayes" --progress "${hamfolder}" | \
-          while read line; do echo "sa_learn: $line"; done
+          while read line; do echo "sa_learn: $line"; done || true
         sa-learn --sync | \
-          while read line; do echo "sa_learn: $line"; done
+          while read line; do echo "sa_learn: $line"; done || true
       else
         echo "sa_learn: No Archive folder found - skipping"
       fi


### PR DESCRIPTION
## Summary

- `sa-learn` returns exit code 1 when it processes messages but learns no new tokens (all already learned)
- With `set -o errexit`, this kills the script and supervisor restarts it in a loop until it enters `FATAL` state
- Add `|| true` to tolerate this expected non-zero exit code

Found during staging validation of the unified postfix+milters container on production.

## Test plan

- [ ] CI passes
- [ ] Deploy to staging, verify `sa_learn` stays in RUNNING state after processing accounts with no new spam

🤖 Generated with [Claude Code](https://claude.com/claude-code)