### PR TITLE
Fix milter and Dovecot socket permission denied errors

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -251,6 +251,23 @@ jobs:
         echo "$perms" | grep -q '775'
         echo "Socket directory permissions verified"
 
+    - name: Verify milter sockets are accessible by postfix
+      run: |
+        # Wait for sockets to be created
+        for i in $(seq 1 15); do
+          if docker exec milter-test test -S /var/spool/postfix/private/dkim; then break; fi
+          sleep 1
+        done
+        # DKIM socket: must be group opendkim so postfix (in opendkim group) can access
+        dkim_perms=$(docker exec milter-test stat -c '%U:%G %a' /var/spool/postfix/private/dkim)
+        echo "DKIM socket: $dkim_perms"
+        echo "$dkim_perms" | grep -q 'opendkim'
+        # DMARC socket: same requirement
+        dmarc_perms=$(docker exec milter-test stat -c '%U:%G %a' /var/spool/postfix/private/dmarc)
+        echo "DMARC socket: $dmarc_perms"
+        echo "$dmarc_perms" | grep -q 'opendkim'
+        echo "Milter socket permissions verified"
+
     - name: Verify DKIM configuration was generated
       run: |
         docker exec milter-test test -f /etc/opendkim.conf

--- a/configs/supervisord.conf
+++ b/configs/supervisord.conf
@@ -98,8 +98,7 @@ stderr_logfile_maxbytes = 0
 
 [program:opendkim]
 command         = /scripts/opendkim.sh
-# Keep in sync with postfix user id
-user            = syslog
+# Started as root so opendkim can drop to syslog:opendkim (see UserID in opendkim.conf)
 autostart       = true
 autorestart     = true
 startsecs       = 5

--- a/scripts/create_opendkim_conf.sh
+++ b/scripts/create_opendkim_conf.sh
@@ -28,8 +28,9 @@ OversignHeaders		From
 KeyTable                refile:/etc/opendkim/KeyTable
 SigningTable            refile:/etc/opendkim/SigningTable
 
-# Keep in sync with postfix uid
-UserID			syslog
+# Run as syslog user with opendkim group so postfix (in opendkim group) can
+# access the socket.  Requires the process to start as root (supervisor default).
+UserID			syslog:opendkim
 UMask			007
 
 Socket			local:/var/spool/postfix/${DKIM_SOCKET_PATH}

--- a/scripts/opendmarc.sh
+++ b/scripts/opendmarc.sh
@@ -15,8 +15,8 @@ noop() {
 }
 
 if [[ -n "${DMARC_SOCKET_PATH:-}" ]]; then
-  # Keep in sync with postfix uid
-  /usr/sbin/opendmarc -f -c /etc/opendmarc.conf -u syslog  | \
+  # UserID is set in opendmarc.conf (patched by run.sh)
+  /usr/sbin/opendmarc -f -c /etc/opendmarc.conf  | \
     while read -r line; do echo "opendmarc: $line"; done
 else
   echo "INFO: Not running opendmarc, since no socket path is set"

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -268,6 +268,8 @@ RejectFailures true
 IgnoreAuthenticatedClients true
 RequiredHeaders    true
 SPFSelfValidate true
+UserID syslog:opendkim
+UMask 007
 EOF
   fi
 fi
@@ -297,6 +299,16 @@ for dir in "${!SOCKET_DIRS[@]}"; do
   chmod 775 "${dir}"
 done
 chown -R debian-spamd:debian-spamd /var/lib/spamass-milter
+
+# Fix Dovecot socket permissions: the Dovecot container creates auth and LMTP
+# sockets with its own UID (101), but in this container postfix has a different
+# UID (106 due to milter packages creating system users first).  Change ownership
+# so postfix can connect.
+for _sock in /var/spool/postfix/private/auth /var/spool/postfix/private/dovecot-lmtp; do
+  if [[ -S "$_sock" ]]; then
+    chown postfix:postfix "$_sock"
+  fi
+done
 
 echo_exec_banner
 exec supervisord -c /etc/supervisord.conf


### PR DESCRIPTION
## Summary
- **OpenDKIM**: Use `UserID syslog:opendkim` so socket group is `opendkim` (accessible to postfix); start as root in supervisor so `setgid` works
- **OpenDMARC**: Add `UserID syslog:opendkim` and `UMask 007` to config; remove `-u syslog` CLI flag
- **Dovecot sockets**: `chown` auth and LMTP sockets to postfix before starting supervisord

## Root cause
The unified container's postfix user has **UID 106** (shifted by milter package system users), but:
- Dovecot creates sockets as UID 101 with mode `0600`
- opendkim/opendmarc create sockets with group `syslog` (GID 103) instead of `opendkim` (GID 104)

| Socket | Owner | Mode | Problem |
|--------|-------|------|---------|
| `private/auth` | 101:101 | 0600 | Wrong UID, owner-only |
| `private/dkim` | 102:103 | 0770 | postfix not in syslog group |
| `private/dmarc` | 102:103 | 0775 | socket needs write, other only has r-x |

## Test plan
- [x] CI: build-and-smoke-test
- [x] CI: milter-integration-test (includes new socket permission check)
- [ ] Deploy to production and verify no "Permission denied" in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)