### PR TITLE
Fix spamass socket permissions and DMARC outbound rejection

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -248,14 +248,15 @@ jobs:
         perms=$(docker exec milter-test stat -c '%U:%G %a' /var/spool/postfix/private)
         echo "Socket dir permissions: $perms"
         echo "$perms" | grep -q 'postfix:opendkim'
-        echo "$perms" | grep -q '775'
+        echo "$perms" | grep -q '2775'
         echo "Socket directory permissions verified"
 
     - name: Verify milter sockets are accessible by postfix
       run: |
         # Wait for sockets to be created
         for i in $(seq 1 15); do
-          if docker exec milter-test test -S /var/spool/postfix/private/dkim; then break; fi
+          if docker exec milter-test test -S /var/spool/postfix/private/dkim && \
+             docker exec milter-test test -S /var/spool/postfix/private/spamass; then break; fi
           sleep 1
         done
         # DKIM socket: must be group opendkim so postfix (in opendkim group) can access
@@ -266,6 +267,10 @@ jobs:
         dmarc_perms=$(docker exec milter-test stat -c '%U:%G %a' /var/spool/postfix/private/dmarc)
         echo "DMARC socket: $dmarc_perms"
         echo "$dmarc_perms" | grep -q 'opendkim'
+        # Spamass socket: inherits opendkim group via setgid bit on directory
+        spamass_perms=$(docker exec milter-test stat -c '%U:%G %a' /var/spool/postfix/private/spamass)
+        echo "Spamass socket: $spamass_perms"
+        echo "$spamass_perms" | grep -q 'opendkim'
         echo "Milter socket permissions verified"
 
     - name: Verify DKIM configuration was generated

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -148,12 +148,14 @@ if [[ -n "${RCP_RESTR:-}" ]]; then
   do_postconf -e "smtpd_recipient_restrictions=${RCP_RESTR:-}"
 fi
 
-# Add DKIM milter spec
+# Add DKIM milter spec (used for both inbound verification and outbound signing)
 if [[ -n "${DKIM_SOCKET_PATH:-}" ]]; then
   SMTPD_MILTERS="${SMTPD_MILTERS:+$SMTPD_MILTERS,}local:${DKIM_SOCKET_PATH}"
+  NON_SMTPD_MILTERS="${NON_SMTPD_MILTERS:+$NON_SMTPD_MILTERS,}local:${DKIM_SOCKET_PATH}"
 fi
 
-# Add DMARC milter spec
+# Add DMARC milter spec (inbound only — cleanup daemon lacks SASL auth context,
+# so IgnoreAuthenticatedClients would not work for non-smtpd milters)
 if [[ -n "${DMARC_SOCKET_PATH:-}" ]]; then
   SMTPD_MILTERS="${SMTPD_MILTERS:+$SMTPD_MILTERS,}local:${DMARC_SOCKET_PATH}"
 fi
@@ -165,7 +167,11 @@ if [[ -n "${SMTPD_MILTERS:-}" ]]; then
   do_postconf -e "smtpd_milters=${SMTPD_MILTERS}"
   do_postconf -e 'milter_default_action=accept'
   do_postconf -e 'milter_protocol=6'
-  do_postconf -e 'non_smtpd_milters=$smtpd_milters'
+fi
+if [[ -n "${NON_SMTPD_MILTERS:-}" ]]; then
+  echo "Activating non_smtpd_milters with:"
+  echo "   non_smtpd_milters=${NON_SMTPD_MILTERS}"
+  do_postconf -e "non_smtpd_milters=${NON_SMTPD_MILTERS}"
 fi
 
 if [[ -n "${DOVECOT_LMTP_PATH:-}" ]]; then
@@ -260,6 +266,9 @@ if [[ -n "${DMARC_SOCKET_PATH:-}" ]]; then
 
   # Configuration taken from https://www.linuxbabe.com/mail-server/opendmarc-postfix-ubuntu
   sed 's@^Socket local:.*@Socket local:/var/spool/postfix/'"${DMARC_SOCKET_PATH}"'@' -i.bak /etc/opendmarc.conf
+  # Replace default UserID and UMask so there are no duplicates
+  sed -i 's@^UserID opendmarc@UserID syslog:opendkim@' /etc/opendmarc.conf
+  sed -i 's@^UMask 0002@UMask 007@' /etc/opendmarc.conf
   if ! grep -q '^AuthservID OpenDMARC' /etc/opendmarc.conf; then
     cat <<EOF >> /etc/opendmarc.conf
 AuthservID OpenDMARC
@@ -268,8 +277,6 @@ RejectFailures true
 IgnoreAuthenticatedClients true
 RequiredHeaders    true
 SPFSelfValidate true
-UserID syslog:opendkim
-UMask 007
 EOF
   fi
 fi
@@ -296,7 +303,7 @@ for path in "${POSTGREY_SOCKET_PATH:-}" "${SPAMASS_SOCKET_PATH:-}" "${DKIM_SOCKE
 done
 for dir in "${!SOCKET_DIRS[@]}"; do
   chown postfix:opendkim "${dir}"
-  chmod 775 "${dir}"
+  chmod 2775 "${dir}"
 done
 chown -R debian-spamd:debian-spamd /var/lib/spamass-milter
 


### PR DESCRIPTION
## Summary
- **Spamass socket**: Set setgid bit (`2775`) on `private/` directory so all sockets inherit the `opendkim` group — fixes `connect to private/spamass: Permission denied`
- **DMARC outbound rejection**: Only include DKIM in `non_smtpd_milters`. DMARC stays in `smtpd_milters` only, because the cleanup daemon lacks SASL auth context, making `IgnoreAuthenticatedClients` ineffective and causing `4.7.1 Service unavailable` on outbound mail
- **opendmarc.conf**: Replace default `UserID`/`UMask` in-place instead of appending duplicates

## Test plan
- [x] CI: build-and-smoke-test
- [x] CI: milter-integration-test (verifies setgid bit + spamass socket group)
- [x] Deploy and verify no Permission denied or milter-reject errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)