### PR TITLE
Fix spamass-milter socket: set umask 007 for group write

### DIFF
--- a/scripts/spamass.sh
+++ b/scripts/spamass.sh
@@ -17,6 +17,7 @@ noop() {
 }
 
 if [[ -n "${SPAMASS_SOCKET_PATH:-}" ]]; then
+  umask 007
   /usr/sbin/spamass-milter -r 15 -p "${SPAMASS_SOCKET}" | \
     while read -r line; do echo "spamass-milter: $line"; done
 else


### PR DESCRIPTION
## Summary
spamass-milter creates its socket with mode 755 (default umask). The setgid bit on `private/` correctly sets the group to opendkim, but group only gets `r-x` — Unix sockets require **write** permission to connect, causing `Permission denied`.

Fix: `umask 007` before launching spamass-milter, so the socket gets mode 770.

## Test plan
- [ ] CI green
- [ ] No more `connect to private/spamass: Permission denied` in production logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)