### PR TITLE
Fix DKIM key rejection and remove stale config volumes

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -289,7 +289,7 @@ jobs:
         docker exec milter-test test -f /var/lib/opendkim/dkim.private
         key_perms=$(docker exec milter-test stat -c '%U:%G %a' /var/lib/opendkim/dkim.private)
         echo "DKIM key permissions: $key_perms"
-        echo "$key_perms" | grep -q 'syslog:opendkim'
+        echo "$key_perms" | grep -q 'syslog:syslog'
         # KeyTable must point to the runtime copy, not the secret mount
         docker exec milter-test grep -q '/var/lib/opendkim/dkim.private' /etc/opendkim/KeyTable
         echo "DKIM key accessible by opendkim"

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ EXPOSE 587
 EXPOSE 465
 EXPOSE 25
 
-VOLUME [ "/var/mail", "/var/spool/postfix", "/etc/postfix", "/etc/opendkim/keys", "/vhome/users" ]
+VOLUME [ "/var/mail", "/var/spool/postfix", "/vhome/users" ]
 
 COPY scripts/* /scripts/
 COPY configs/* /etc/

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -172,6 +172,8 @@ if [[ -n "${SMTPD_MILTERS:-}" ]]; then
   do_postconf -e "smtpd_milters=${SMTPD_MILTERS}"
   do_postconf -e 'milter_default_action=accept'
   do_postconf -e 'milter_protocol=6'
+  # Explicitly clear non_smtpd_milters in case a previous deploy set it.
+  do_postconf -e 'non_smtpd_milters='
 fi
 
 if [[ -n "${DOVECOT_LMTP_PATH:-}" ]]; then
@@ -209,6 +211,17 @@ else
   echo "No TLS configured"
 fi
 
+
+# Disable milters on the submission port: authenticated outbound mail must not
+# pass through DKIM/DMARC milters because PostSRSd rewrites the envelope sender
+# to @smtp.nesono.com before cleanup runs the milters, and there is no DKIM key
+# for that domain.
+if [[ -n "${SMTPD_MILTERS:-}" ]]; then
+  MILTER_OFF_OPT="  -o smtpd_milters="
+  if ! grep -q 'smtpd_milters=' <(grep -A5 '^submission\s\+inet' /etc/postfix/master.cf); then
+    sed -i "/^submission\s\+inet/a\\${MILTER_OFF_OPT}" /etc/postfix/master.cf
+  fi
+fi
 
 # Patch the smtp and submission lines to allow xclient from specific hosts
 # This is idempotent: only adds the -o line if not already present after the service line
@@ -263,8 +276,8 @@ if [[ -n "${DKIM_SOCKET_PATH:-}" ]]; then
   DKIM_KEY_RUNTIME="/var/lib/opendkim/dkim.private"
   mkdir -p /var/lib/opendkim
   cp "${DKIM_KEY_PATH}" "${DKIM_KEY_RUNTIME}"
-  chown syslog:opendkim "${DKIM_KEY_RUNTIME}"
-  chmod 440 "${DKIM_KEY_RUNTIME}"
+  chown syslog:syslog "${DKIM_KEY_RUNTIME}"
+  chmod 400 "${DKIM_KEY_RUNTIME}"
   DKIM_KEY_PATH="${DKIM_KEY_RUNTIME}"
 
   # Create opendkim.conf from template


### PR DESCRIPTION
## Summary
- **DKIM key permissions**: Changed from `syslog:opendkim 440` to `syslog:syslog 400`. OpenDKIM refuses to load keys that are group-readable when the group has multiple members (both `syslog` and `postfix` are in the `opendkim` group).
- **Remove anonymous volumes**: Removed `/etc/postfix` and `/etc/opendkim/keys` from `VOLUME` in Dockerfile. These config directories are rebuilt by `run.sh` on every start — persisting them caused stale settings (e.g. `non_smtpd_milters`) to leak across deploys.
- **Clear `non_smtpd_milters`**: Explicitly set to empty on startup as safety net against leftover config.
- **Disable milters on submission port**: Defense-in-depth for outbound authenticated mail.

## Test plan
- [x] CI milter-integration-test passes (DKIM key permissions check updated)
- [ ] Verified on production: outbound mail from `jochen.issing@issing.link` → `jochen.issing@icloud.com` delivers successfully after hotfix

🤖 Generated with [Claude Code](https://claude.com/claude-code)