### PR TITLE
Create /etc/opendkim dir before writing KeyTable

### DIFF
--- a/scripts/create_opendkim_conf.sh
+++ b/scripts/create_opendkim_conf.sh
@@ -71,6 +71,7 @@ SendReports             yes
 RequiredHeaders        yes
 EOF
 
+mkdir -p "$(dirname "${KEY_TABLE}")"
 # Clear KeyTable
 rm -rf "${KEY_TABLE}"
 # Fill KeyTable


### PR DESCRIPTION
## Summary
- After #42 removed `/etc/opendkim/keys` from `VOLUME`, the `/etc/opendkim/` directory is no longer implicitly created. `create_opendkim_conf.sh` fails writing `KeyTable` to a nonexistent directory.
- Fix: `mkdir -p` before writing.

## Test plan
- [x] CI passes
- [ ] Container starts and opendkim loads KeyTable successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)