### PR TITLE
Disable SRS on submission port instead of disabling milters

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -212,15 +212,12 @@ else
 fi
 
 
-# Disable milters on the submission port: authenticated outbound mail must not
-# pass through DKIM/DMARC milters because PostSRSd rewrites the envelope sender
-# to @smtp.nesono.com before cleanup runs the milters, and there is no DKIM key
-# for that domain.
-if [[ -n "${SMTPD_MILTERS:-}" ]]; then
-  MILTER_OFF_OPT="  -o smtpd_milters="
-  if ! grep -q 'smtpd_milters=' <(grep -A5 '^submission\s\+inet' /etc/postfix/master.cf); then
-    sed -i "/^submission\s\+inet/a\\${MILTER_OFF_OPT}" /etc/postfix/master.cf
-  fi
+# Disable SRS on the submission port: authenticated users' mail must keep its
+# original envelope sender so DKIM and SPF align for DMARC.  SRS is only needed
+# for forwarded mail, which goes through the smtp transport, not submission.
+SRS_OFF_OPT="  -o sender_canonical_maps="
+if ! grep -q 'sender_canonical_maps=' <(grep -A5 '^submission\s\+inet' /etc/postfix/master.cf); then
+  sed -i "/^submission\s\+inet/a\\${SRS_OFF_OPT}" /etc/postfix/master.cf
 fi
 
 # Patch the smtp and submission lines to allow xclient from specific hosts


### PR DESCRIPTION
## Summary
- **Replaced** `smtpd_milters=` override on submission with `sender_canonical_maps=`
- The previous fix disabled milters on port 587, which prevented DKIM signing → DMARC rejection at iCloud and other strict receivers
- The correct fix: disable SRS rewriting on submission so authenticated users' mail keeps its original envelope sender, allowing both SPF and DKIM to align for DMARC
- SRS remains active on port 25 for forwarded mail (sieve redirects)

## Context
- Outbound mail from `roland@noerpel.net` was getting SRS-rewritten to `SRS0=...@smtp.nesono.com` even on direct submission
- Without DKIM signing (milters disabled) and with broken SPF alignment (SRS), DMARC failed: `554 5.7.1 DMARC unauthenticated mail is prohibited`
- Verified fix on production: mail from `jochen.issing@issing.link` → `jochen.issing@icloud.com` delivers successfully

## Test plan
- [x] CI passes
- [ ] Outbound mail via submission (587) is DKIM-signed and passes DMARC
- [ ] Forwarded mail (sieve) still gets SRS rewriting

🤖 Generated with [Claude Code](https://claude.com/claude-code)