### PR TITLE
Integrate postfix_exporter into the container

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -65,6 +65,9 @@ jobs:
     - name: Verify SRS config contains domain
       run: docker exec postfix-test grep 'mail.example.com' /etc/default/postsrsd
 
+    - name: Verify postfix_exporter binary is installed
+      run: docker exec postfix-test test -x /usr/local/bin/postfix_exporter
+
     - name: Verify milter packages are installed
       run: |
         docker exec postfix-test dpkg -l postgrey | grep -q '^ii'
@@ -194,6 +197,7 @@ jobs:
           -e DKIM_KEY_PATH=/etc/opendkim/keys/mail.private \
           -e DMARC_SOCKET_PATH=private/dmarc \
           -e MAIL_HOSTNAME=mail.example.com \
+          -e POSTFIX_EXPORTER_ENABLE=1 \
           -v /tmp/sql_user.txt:/tmp/sql_user.txt:ro \
           -v /tmp/sql_password.txt:/tmp/sql_password.txt:ro \
           -v /tmp/dkim-keys:/etc/opendkim/keys:ro \
@@ -201,7 +205,7 @@ jobs:
 
     - name: Wait for all services to reach RUNNING state
       run: |
-        SERVICES="postfix postsrs rsyslog spamd sa_learn postgrey spamass opendkim opendmarc"
+        SERVICES="postfix postsrs rsyslog spamd sa_learn postgrey spamass opendkim opendmarc postfix_exporter"
         for i in $(seq 1 60); do
           all_running=true
           for svc in $SERVICES; do
@@ -226,7 +230,7 @@ jobs:
     - name: Verify all milter services are running
       run: |
         docker exec milter-test supervisorctl -c /etc/supervisord.conf status
-        for svc in postfix postsrs rsyslog spamd sa_learn postgrey spamass opendkim opendmarc; do
+        for svc in postfix postsrs rsyslog spamd sa_learn postgrey spamass opendkim opendmarc postfix_exporter; do
           status=$(docker exec milter-test supervisorctl -c /etc/supervisord.conf status $svc | awk '{print $2}')
           echo "$svc: $status"
           if [[ "$status" != "RUNNING" ]]; then
@@ -272,6 +276,13 @@ jobs:
         echo "Spamass socket: $spamass_perms"
         echo "$spamass_perms" | grep -q 'opendkim'
         echo "Milter socket permissions verified"
+
+    - name: Verify postfix_exporter metrics endpoint
+      run: |
+        response=$(docker exec milter-test bash -c 'echo -e "GET /metrics HTTP/1.0\r\nHost: localhost\r\n\r\n" | nc -w 5 127.0.0.1 9154 | head -20')
+        echo "$response"
+        echo "$response" | grep -q 'postfix'
+        echo "Postfix exporter metrics endpoint verified"
 
     - name: Verify DKIM configuration was generated
       run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,9 @@
+FROM golang:1.25 AS exporter-builder
+WORKDIR /src
+RUN git clone https://github.com/nesono/postfix_exporter.git .
+RUN go mod download && go mod verify
+RUN go build -tags nosystemd -o /bin/postfix_exporter
+
 FROM ubuntu:24.04
 LABEL maintainer="Jochen Issing <c.333+github@nesono.com> (@jochenissing)"
 
@@ -45,9 +51,12 @@ RUN mkdir -p /vhome/users/ && \
 # Also run something like the following command to change all existing files:
 # chown <uid>:<gid> -R /svc/volumes/mail
 
+COPY --from=exporter-builder /bin/postfix_exporter /usr/local/bin/postfix_exporter
+
 EXPOSE 587
 EXPOSE 465
 EXPOSE 25
+EXPOSE 9154
 
 VOLUME [ "/var/mail", "/var/spool/postfix", "/vhome/users" ]
 

--- a/configs/supervisord.conf
+++ b/configs/supervisord.conf
@@ -117,3 +117,14 @@ stdout_logfile  = /dev/stdout
 stderr_logfile  = /dev/stderr
 stdout_logfile_maxbytes = 0
 stderr_logfile_maxbytes = 0
+
+[program:postfix_exporter]
+command         = /scripts/postfix_exporter.sh
+autostart       = true
+autorestart     = true
+startsecs       = 5
+stopwaitsecs    = 5
+stdout_logfile  = /dev/stdout
+stderr_logfile  = /dev/stderr
+stdout_logfile_maxbytes = 0
+stderr_logfile_maxbytes = 0

--- a/scripts/postfix_exporter.sh
+++ b/scripts/postfix_exporter.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -o errexit -o pipefail -o nounset
+
+noop() {
+    while true; do
+        sleep infinity || sleep 2147483647
+    done
+}
+
+if [[ "${POSTFIX_EXPORTER_ENABLE:-}" == "1" ]]; then
+  exec /usr/local/bin/postfix_exporter \
+    --postfix.logfile_path=/var/log/mail.log \
+    --postfix.showq_path=/var/spool/postfix/public/showq
+else
+  echo "INFO: Not running postfix_exporter, since POSTFIX_EXPORTER_ENABLE is not set"
+  noop
+fi


### PR DESCRIPTION
## Summary
- Builds `postfix_exporter` from source in a Go multi-stage build (`-tags nosystemd` to avoid libsystemd dependency)
- Adds supervisord-managed `postfix_exporter` service, enabled via `POSTFIX_EXPORTER_ENABLE=1`
- Exporter reads `/var/log/mail.log` directly (via rsyslog) and accesses showq socket in-container
- Eliminates the need for a separate container with Docker socket access
- Adds CI smoke tests for the exporter binary and metrics endpoint

## Changes
- `Dockerfile`: Go builder stage + binary copy + expose 9154
- `scripts/postfix_exporter.sh`: Wrapper script (noop when disabled)
- `configs/supervisord.conf`: New `[program:postfix_exporter]` entry
- `.github/workflows/docker-image.yml`: CI verification steps

## Test plan
- [ ] CI passes (build + smoke test + milter integration test with exporter)
- [ ] Deploy with `POSTFIX_EXPORTER_ENABLE=1` and verify `/metrics` endpoint returns postfix metrics
- [ ] After validation, remove standalone `postfix_exporter` service from infrastructure docker-compose
- [ ] Update prometheus scrape target from `postfix_exporter:9154` to `postfix:9154`

Closes nesono/infrastructure#100

🤖 Generated with [Claude Code](https://claude.com/claude-code)